### PR TITLE
Fix virtual device service Docker host name

### DIFF
--- a/docker-files/application.properties
+++ b/docker-files/application.properties
@@ -50,7 +50,7 @@ application.auto-create-device=true
 application.collection-frequency=15
 
 #default device service settings
-service.name=device-virtual
+service.name=edgex-device-virtual
 service.host=${service.name}
 service.labels=virtual
 service.callback=/api/v1/callback


### PR DESCRIPTION
Fixed the service.name in application.properties to match the rest of the
project.

Reference for docker-device-virtual Issue #2

Signed-off-by: Tyler Cox <tyler_cox@dell.com>