### PR TITLE
Add distributionManagement for artifact storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<nexusproxy>https://nexus.edgexfoundry.org</nexusproxy>
+		<repobasepath>content/repositories</repobasepath>
 	</properties>
 
 	<parent>
@@ -36,6 +38,14 @@
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>1.3.8.RELEASE</version>
 	</parent>
+
+	<distributionManagement>
+		<snapshotRepository>
+			<id>snapshots</id>
+			<name>EdgeX Snapshot Repository</name>
+			<url>${nexusproxy}/${repobasepath}/snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
To store the build SNAPSHOTS of artifacts a distributionManagement
section is required in the pom.xml

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>