### PR TITLE
Fix spring-boot-maven-plugin issue in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,18 +211,6 @@
 	<build>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-maven-plugin</artifactId>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
-					</configuration>
-				</plugin>
 				<!-- Mandatory plugins for using Spock -->
 				<plugin>
 					<!-- The gmavenplus plugin is used to compile Groovy code. To learn more 
@@ -239,19 +227,33 @@
 						</execution>
 					</executions>
 				</plugin>
-				<plugin>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<configuration>
-						<groups>${testcase.groups}</groups>
-						<useFile>false</useFile>
-						<includes>
-							<include>**/*Spec.java</include>
-							<include>**/*Test.java</include>
-						</includes>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<groups>${testcase.groups}</groups>
+					<useFile>false</useFile>
+					<includes>
+						<include>**/*Spec.java</include>
+						<include>**/*Test.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 	<repositories>
 		<repository>


### PR DESCRIPTION
Looks like with <pluginManagement> </pluginManagement>,
sprint-boot-maven-plugin can't be included into the maven build,
consequently, the spring boot can't work properly with the error:
no main manifest attribute, in
/home/martin/.m2/repository/org/edgexfoundry/device-virtual/
1.0.0-SNAPSHOT/device-virtual-1.0.0-SNAPSHOT.jar

Just remove <pluginManagement> </pluginManagement>, the
problem can be resolved.

BTW, I am using command line not  Eclipse IDE